### PR TITLE
Fix DateTimeOffset

### DIFF
--- a/source/Windows 10 IoT Core/DHT Solution/Sensors.OneWire/MainPage.xaml.cs
+++ b/source/Windows 10 IoT Core/DHT Solution/Sensors.OneWire/MainPage.xaml.cs
@@ -16,7 +16,7 @@ namespace Sensors.OneWire
         GpioPin _pin = null;
         private IDht _dht = null;
         private List<int> _retryCount = new List<int>();
-        private DateTimeOffset _startedAt = DateTime.MinValue;
+        private DateTimeOffset _startedAt = DateTimeOffset.MinValue;
 
         public MainPage()
         {


### PR DESCRIPTION
Exception thrown: 'System.ArgumentOutOfRangeException' in mscorlib.ni.dll
Additional information: The UTC time represented when the offset is applied must be between year 0 and 10,000.

Windows 10.0.10586.0
Raspberry Pi 2 Model B

private DateTimeOffset _startedAt = DateTimeOffset.MinValue;

Windows 10.0.10586.0
Raspberry Pi 2 Model B
